### PR TITLE
Fix shift keyhandling

### DIFF
--- a/src/Client/WorldMapWindow.java
+++ b/src/Client/WorldMapWindow.java
@@ -1977,7 +1977,9 @@ public class WorldMapWindow {
     if (keyChar == KeyEvent.VK_BACK_SPACE) {
       if (searchText.length() > 0) searchText = searchText.substring(0, searchText.length() - 1);
     } else {
-      searchText += keyChar;
+      if (keyChar != 65535) {
+        searchText += keyChar;
+      }
     }
 
     buildSearchResults();

--- a/src/Game/KeyboardHandler.java
+++ b/src/Game/KeyboardHandler.java
@@ -177,7 +177,9 @@ public class KeyboardHandler implements KeyListener {
         int n =
             converted == e.getExtendedKeyCode()
                 ? e.getKeyChar()
-                : converted; // with getKeyCode() is always placing letter to upper
+                : keyShift
+                    ? e.getKeyChar()
+                    : converted; // with getKeyCode() is always placing letter to upper
         Reflection.keyDown.invoke(Client.instance, evt, n);
       } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
         // TODO Auto-generated catch block
@@ -240,7 +242,9 @@ public class KeyboardHandler implements KeyListener {
         int n =
             converted == e.getExtendedKeyCode()
                 ? e.getKeyChar()
-                : converted; // with getKeyCode() is always placing letter to upper
+                : keyShift
+                    ? e.getKeyChar()
+                    : converted; // with getKeyCode() is always placing letter to upper
         Reflection.keyUp.invoke(Client.instance, evt, n);
       } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
         // TODO Auto-generated catch block


### PR DESCRIPTION
This fixes 2 problems:

1. Prevents a `[]` character from appearing in the map search box when pressing shift
2. Fixes the inability to type certain special characters such as `:`, `!`, `@`, etc on MacOS.

Since this is such a weird Java quirk, please test thoroughly for regressions.